### PR TITLE
Add language to exception message.

### DIFF
--- a/ClientLibrary/Microsoft.ProjectOxford.Text/Core/Exceptions/LanguageNotSupportedException.cs
+++ b/ClientLibrary/Microsoft.ProjectOxford.Text/Core/Exceptions/LanguageNotSupportedException.cs
@@ -64,7 +64,7 @@ namespace Microsoft.ProjectOxford.Text.Core.Exceptions
             get
             {
                 var sb = new StringBuilder();
-                sb.AppendLine(string.Format("Language {0} is not supported. Supported languages are:"));
+                sb.AppendLine(string.Format("Language {0} is not supported. Supported languages are:", this.InvalidLanguage));
 
                 foreach (var language in this.ValidLanguages)
                     sb.AppendLine(language);


### PR DESCRIPTION
The LanguageNotSupportedException uses string.Format but doesn't actually include the invalid language, only the '{0}' placeholder.